### PR TITLE
Pass ID to the job in onAdded()

### DIFF
--- a/jobqueue/src/com/path/android/jobqueue/BaseJob.java
+++ b/jobqueue/src/com/path/android/jobqueue/BaseJob.java
@@ -71,7 +71,7 @@ abstract public class BaseJob implements Serializable {
      * Also, if your app crashes right after adding the job, {@code onRun} might be called without an {@code onAdded} call
      * @param id the job's ID which can be used to check the job's status
      */
-    abstract public void onAdded(String id);
+    abstract public void onAdded(long id);
 
     /**
      * The actual method that should to the work

--- a/jobqueue/src/com/path/android/jobqueue/BaseJob.java
+++ b/jobqueue/src/com/path/android/jobqueue/BaseJob.java
@@ -69,8 +69,9 @@ abstract public class BaseJob implements Serializable {
      * this means job will eventually run. this is a good time to update local database and dispatch events
      * Changes to this class will not be preserved if your job is persistent !!!
      * Also, if your app crashes right after adding the job, {@code onRun} might be called without an {@code onAdded} call
+     * @param id the job's ID which can be used to check the job's status
      */
-    abstract public void onAdded();
+    abstract public void onAdded(String id);
 
     /**
      * The actual method that should to the work

--- a/jobqueue/src/com/path/android/jobqueue/JobManager.java
+++ b/jobqueue/src/com/path/android/jobqueue/JobManager.java
@@ -514,7 +514,7 @@ public class JobManager implements NetworkEventProvider.Listener {
             //inject members b4 calling onAdded
             dependencyInjector.inject(baseJob);
         }
-        jobHolder.getBaseJob().onAdded();
+        jobHolder.getBaseJob().onAdded(id);
         if(baseJob.isPersistent()) {
             synchronized (persistentJobQueue) {
                 clearOnAddedLock(persistentOnAddedLocks, id);


### PR DESCRIPTION
In some cases it is useful when the job knows its own job ID.

Example usecase:
Consider multiple job instances which have been chained by calling addOnBackground() in their respective onRun() method which is very useful for executing requests with result limits and paging. in this case the last job can check if all previous jobs have been executed successfully (by using the IDs they have passed to it via the constructor or stored in a central place) before sending out a finish-event.